### PR TITLE
Add comprehensive .gitignore for Go project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts
+bin/
+
+# Database files
+*.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,53 @@
 # Build artifacts
 bin/
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
 
 # Database files
 *.db
+*.sqlite
+*.sqlite3
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+logs/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp


### PR DESCRIPTION
## Summary
- Add comprehensive .gitignore to exclude build artifacts, database files, and development files
- Includes Go-specific patterns, IDE files, OS files, and temporary files
- Prevents accidental commits of local development artifacts

## Test plan
- [x] Verify .gitignore patterns work correctly
- [x] Confirm existing tracked files remain unaffected
- [x] Test that new ignored file types are properly excluded

🤖 Generated with [Claude Code](https://claude.ai/code)